### PR TITLE
Fix/pagination event filter bug

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0b8fb271884e10d987d227acccb3234e739a827b0209df9cc10474c0712b46df"
+            "sha256": "214b56957a335aa8826220ea9c9b79dfc94306e1c47e29497120d44e01120b9b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -70,14 +70,6 @@
             ],
             "version": "==3.0.4"
         },
-        "colorama": {
-            "hashes": [
-                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
-                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.1"
-        },
         "codecov": {
             "hashes": [
                 "sha256:8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788",
@@ -85,6 +77,14 @@
             ],
             "index": "pypi",
             "version": "==2.0.15"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
+                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.1"
         },
         "coverage": {
             "hashes": [
@@ -359,6 +359,14 @@
                 "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
             ],
             "version": "==2.2.5"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
+                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.1"
         },
         "isort": {
             "hashes": [

--- a/app/content/filters.py
+++ b/app/content/filters.py
@@ -16,7 +16,7 @@ class EventFilter(FilterSet):
     """
         Filters events by category and expired. Works with search query
     """
-    expired = BooleanFilter(method='filter_expired', label='Expired')
+    expired = BooleanFilter(method='filter_expired', label='Newest')
 
     class Meta:
         model = Event 

--- a/app/content/views.py
+++ b/app/content/views.py
@@ -40,20 +40,12 @@ class EventViewSet(viewsets.ModelViewSet):
     """
     serializer_class = EventSerializer
     permission_classes = [HS_Drift_Promo]
-    queryset = Event.objects.all()
+    queryset = Event.objects.all().order_by('start')
     pagination_class = BasePagination
 
     filter_backends = [DjangoFilterBackend, filters.SearchFilter]
     filterset_class = EventFilter
     search_fields = ['title']
-
-    def get_queryset(self):
-        query = self.request.query_params
-
-        if (not len(query) and not len(self.kwargs)):
-            return Event.objects.filter(start__gte=CHECK_IF_EXPIRED()).order_by('start')
-        return Event.objects.all().order_by('start')
- 
 
 class WarningViewSet(viewsets.ModelViewSet):
 

--- a/app/content/views.py
+++ b/app/content/views.py
@@ -36,16 +36,22 @@ class NewsViewSet(viewsets.ModelViewSet):
 class EventViewSet(viewsets.ModelViewSet):
     """
     API endpoint to display all upcoming events and filter them by title, category and expired
-        Includes expired events by default, but includes them in search results
+        Excludes expired events by default, but includes them in search results
     """
     serializer_class = EventSerializer
     permission_classes = [HS_Drift_Promo]
-    queryset = Event.objects.all().order_by('start')
+    queryset = Event.objects.filter(start__gte=CHECK_IF_EXPIRED()).order_by('start')
     pagination_class = BasePagination
 
     filter_backends = [DjangoFilterBackend, filters.SearchFilter]
     filterset_class = EventFilter
     search_fields = ['title']
+
+    def get_queryset(self):
+            
+        if (self.kwargs or 'expired' in self.request.query_params):
+            return Event.objects.all().order_by('start')
+        return self.queryset
 
 class WarningViewSet(viewsets.ModelViewSet):
 

--- a/app/content/views.py
+++ b/app/content/views.py
@@ -36,7 +36,7 @@ class NewsViewSet(viewsets.ModelViewSet):
 class EventViewSet(viewsets.ModelViewSet):
     """
     API endpoint to display all upcoming events and filter them by title, category and expired
-        Excludes expired events by default, but includes them in search results
+        Includes expired events by default, but includes them in search results
     """
     serializer_class = EventSerializer
     permission_classes = [HS_Drift_Promo]

--- a/app/content/views.py
+++ b/app/content/views.py
@@ -36,7 +36,7 @@ class NewsViewSet(viewsets.ModelViewSet):
 class EventViewSet(viewsets.ModelViewSet):
     """
     API endpoint to display all upcoming events and filter them by title, category and expired
-        Excludes expired events by default, but includes them in search results
+        Excludes expired events by default: to include expired in results, add '?expired=true'
     """
     serializer_class = EventSerializer
     permission_classes = [HS_Drift_Promo]


### PR DESCRIPTION
Expired events are excluded by default, also when searching. To retrieve expired events as well, add '?expired=true' in a seperate call. Works with pagination.