### PR TITLE
Refactor/job post view set

### DIFF
--- a/app/content/filters.py
+++ b/app/content/filters.py
@@ -2,7 +2,7 @@
 from django_filters.rest_framework import DjangoFilterBackend, BooleanFilter, FilterSet
 
 # Model imports
-from .models import Event
+from .models import Event, JobPost
 
 # Django imports
 from django.utils import timezone
@@ -10,7 +10,7 @@ from django.utils import timezone
 # Datetime and other import
 from datetime import timedelta
 
-CHECK_IF_EXPIRED = lambda : timezone.now()-timedelta(days=1)
+CHECK_IF_EXPIRED = lambda : timezone.now()-timedelta(days=1) 
 
 class EventFilter(FilterSet):
     """
@@ -29,3 +29,23 @@ class EventFilter(FilterSet):
         if value:
             return queryset.filter(start__lt=CHECK_IF_EXPIRED()).order_by('-start')
         return queryset.filter(start__gte=CHECK_IF_EXPIRED()).order_by('start')
+
+class JobPostFilter(FilterSet):
+    """
+        Filters job posts by expired
+    """
+    expired = BooleanFilter(method='filter_expired', label='Expired')
+
+    class Meta:
+        model: JobPost
+        fields = ['company', 'expired']
+
+    """
+    @param value: boolean for determining if expired or not is found in querystring
+    """
+    def filter_expired(self, queryset, name, value): 
+        if value:
+            return queryset.filter(deadline__lt=CHECK_IF_EXPIRED()).order_by('-deadline')
+        return queryset.filter(deadline__gte=CHECK_IF_EXPIRED()).order_by('deadline')
+
+

--- a/app/content/filters.py
+++ b/app/content/filters.py
@@ -1,5 +1,6 @@
 # Django Filters and Rest Framework imports
-from django_filters.rest_framework import DjangoFilterBackend, BooleanFilter, FilterSet
+from django_filters.rest_framework import DjangoFilterBackend, BooleanFilter, CharFilter, FilterSet
+from rest_framework import filters
 
 # Model imports
 from .models import Event, JobPost
@@ -38,7 +39,7 @@ class JobPostFilter(FilterSet):
 
     class Meta:
         model: JobPost
-        fields = ['company', 'expired']
+        fields = ['expired']
 
     """
     @param value: boolean for determining if expired or not is found in querystring
@@ -47,5 +48,3 @@ class JobPostFilter(FilterSet):
         if value:
             return queryset.filter(deadline__lt=CHECK_IF_EXPIRED()).order_by('-deadline')
         return queryset.filter(deadline__gte=CHECK_IF_EXPIRED()).order_by('deadline')
-
-

--- a/app/content/views.py
+++ b/app/content/views.py
@@ -36,7 +36,7 @@ class NewsViewSet(viewsets.ModelViewSet):
 class EventViewSet(viewsets.ModelViewSet):
     """
     API endpoint to display all upcoming events and filter them by title, category and expired
-        Excludes expired events by default: to include expired in results, add '?expired=true'
+        Excludes expired events by default: to include expired in results, add '&expired=true'
     """
     serializer_class = EventSerializer
     permission_classes = [HS_Drift_Promo]
@@ -68,7 +68,7 @@ class CategoryViewSet(viewsets.ModelViewSet):
 class JobPostViewSet(viewsets.ModelViewSet):
     """
     API endpoint to display all upcoming events and filter them by title, category and expired
-        Excludes expired events by default. To include them in search results, add '?expired=true'
+        Excludes expired events by default: to include expired in search results, add '&expired=true'
     """
 
     serializer_class = JobPostSerializer

--- a/app/content/views.py
+++ b/app/content/views.py
@@ -69,14 +69,8 @@ class CategoryViewSet(viewsets.ModelViewSet):
 
 class JobPostViewSet(viewsets.ModelViewSet):
     """
-        Returns newest by default
-        Returns the newest job posts ordered by deadline
-        Returns job posts matching a search word, ordered by deadline
-        Returns expired job posts, ordered by deadline
-
-        TODO: 
-            - Should be able to search by company by adding '?company='
-                instead of '?search={company}'?
+    API endpoint to display all upcoming events and filter them by title, category and expired
+        Excludes expired events by default. To include them in search results, add '?expired=true'
     """
 
     serializer_class = JobPostSerializer
@@ -92,21 +86,6 @@ class JobPostViewSet(viewsets.ModelViewSet):
         if (self.kwargs or 'expired' in self.request.query_params):
             return JobPost.objects.all().order_by('deadline')
         return self.queryset
-
-    # def get_queryset(self):
-    #     queryset = JobPost.objects.all()
-
-    #     if self.request.method == 'GET' and 'newest' in self.request.GET:
-    #         # Returns the newest job posts ordered by deadline
-    #         return JobPost.objects.filter(deadline__gte=CHECK_IF_EXPIRED()).order_by('deadline')[:25]
-    #     elif self.request.method == 'GET' and 'search' in self.request.GET:
-    #         # Returns job posts matching a search word, ordered by deadline
-    #         return JobPost.objects.filter(Q(title__icontains=self.request.GET.get('search')) | Q(company__icontains=self.request.GET.get('search'))).order_by('deadline')[:25]
-    #     elif self.request.method == 'GET' and 'expired' in self.request.GET:
-    #         # Returns expired job posts, ordered by deadline
-    #         return JobPost.objects.filter(deadline__lte=CHECK_IF_EXPIRED()).order_by('deadline')[:25]
-
-    #     return queryset
 
 
 # Method for accepting company interest forms from the company page


### PR DESCRIPTION
Expired job posts are excluded by default, also when searching. To retrieve expired job posts as well, add '&expired=true' in a seperate call. Works with pagination.