### PR TITLE
Fixed bug with expired events still being sent to client

### DIFF
--- a/app/content/filters.py
+++ b/app/content/filters.py
@@ -5,13 +5,8 @@ from rest_framework import filters
 # Model imports
 from .models import Event, JobPost
 
-# Django imports
-from django.utils import timezone
-
 # Datetime and other import
-from datetime import timedelta
-
-CHECK_IF_EXPIRED = lambda : timezone.now()-timedelta(days=1) 
+from datetime import datetime, timedelta, timezone
 
 class EventFilter(FilterSet):
     """
@@ -28,8 +23,8 @@ class EventFilter(FilterSet):
     """
     def filter_expired(self, queryset, name, value): 
         if value:
-            return queryset.filter(start__lt=CHECK_IF_EXPIRED()).order_by('-start')
-        return queryset.filter(start__gte=CHECK_IF_EXPIRED()).order_by('start')
+            return queryset.filter(start__lt=datetime.now(tz=timezone.utc)-timedelta(days=1)).order_by('-start')
+        return queryset.filter(start__gte=datetime.now(tz=timezone.utc)-timedelta(days=1)).order_by('start')
 
 class JobPostFilter(FilterSet):
     """
@@ -46,5 +41,5 @@ class JobPostFilter(FilterSet):
     """
     def filter_expired(self, queryset, name, value): 
         if value:
-            return queryset.filter(deadline__lt=CHECK_IF_EXPIRED()).order_by('-deadline')
-        return queryset.filter(deadline__gte=CHECK_IF_EXPIRED()).order_by('deadline')
+            return queryset.filter(deadline__lt=datetime.now(tz=timezone.utc)-timedelta(days=1)).order_by('-deadline')
+        return queryset.filter(deadline__gte=datetime.now(tz=timezone.utc)-timedelta(days=1)).order_by('deadline')

--- a/app/content/views.py
+++ b/app/content/views.py
@@ -15,7 +15,7 @@ from .models import News, Event, \
 from .serializers import NewsSerializer, EventSerializer, \
                          WarningSerializer, CategorySerializer, JobPostSerializer
 from app.util.models import Gridable
-from .filters import CHECK_IF_EXPIRED, EventFilter, JobPostFilter
+from .filters import EventFilter, JobPostFilter
 
 # Permission imports
 from app.authentication.permissions import IsMemberOrSafe, IsHSorDrift, HS_Drift_Promo, HS_Drift_NoK
@@ -23,7 +23,8 @@ from app.authentication.permissions import IsMemberOrSafe, IsHSorDrift, HS_Drift
 # Pagination imports
 from .pagination import BasePagination
 
-# Hash, and other imports
+# Datetime, hash, and other imports
+from datetime import datetime, timedelta, timezone
 from django.db.models import Q
 import hashlib
 import json
@@ -40,7 +41,7 @@ class EventViewSet(viewsets.ModelViewSet):
     """
     serializer_class = EventSerializer
     permission_classes = [HS_Drift_Promo]
-    queryset = Event.objects.filter(start__gte=CHECK_IF_EXPIRED()).order_by('start')
+    queryset = Event.objects.filter(start__gte=datetime.now(tz=timezone.utc)-timedelta(days=1)).order_by('start')
     pagination_class = BasePagination
 
     filter_backends = [DjangoFilterBackend, filters.SearchFilter]
@@ -75,7 +76,7 @@ class JobPostViewSet(viewsets.ModelViewSet):
     permission_classes = [HS_Drift_NoK]
     pagination_class = BasePagination
 
-    queryset = JobPost.objects.filter(deadline__gte=CHECK_IF_EXPIRED()).order_by('deadline')
+    queryset = JobPost.objects.filter(deadline__gte=datetime.now(tz=timezone.utc)-timedelta(days=1)).order_by('deadline')
     filter_backends = [DjangoFilterBackend, filters.SearchFilter]
     filterset_class = JobPostFilter
     search_fields = ['title', 'company']


### PR DESCRIPTION
# BUGFIX EXPIRED EVENTS SENT TO CLIENT
## Expired events where still sent to the server after refactoring
Link to Trello task: ...

Comments/issues:


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ X] PR name is descriptive
- [no time ] The PR includes the link to the relevant Trello task
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

- [ X] `python manage.py runserver` was run locally witout errors


## Pull request type

Please check the type of change your PR introduces:
- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
