### PR TITLE
Fix/update user event

### DIFF
--- a/app/content/serializers.py
+++ b/app/content/serializers.py
@@ -78,7 +78,7 @@ class UserEventSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = UserEvent
-        fields = ['user_event_id', 'user_id', 'event', 'is_on_wait', 'has_attended']
+        fields = ['user_id', 'is_on_wait', 'has_attended']
 
 class EventSerializer(serializers.ModelSerializer):
     expired = serializers.BooleanField(read_only=True)

--- a/app/content/views.py
+++ b/app/content/views.py
@@ -165,10 +165,6 @@ class UserEventViewSet(viewsets.ModelViewSet):
     queryset = UserEvent.objects.all()
     lookup_field = 'user_id' 
 
-    def get_object(self):
-        """ Get object with event_id and user_id from url """
-        return UserEvent.objects.get(user__user_id=self.kwargs['user_id'], event__pk=self.kwargs['event_id'])
-
     def list(self, request, event_id):
         """ Returns all user events for given event """
         try:
@@ -217,14 +213,10 @@ class UserEventViewSet(viewsets.ModelViewSet):
         else:
             return Response({'detail': serializer.errors}, status=400)
 
-    def update(self, request, *args, **kwargs):
-        """ 
-        Updates fields passed in request
-        http://localhost:8080/api/v1/events/3/users/ : data in request.body/data
-        """
-        
+    def update(self, request, event_id, user_id, *args, **kwargs):
+        """ Updates fields passed in request """
         try:
-            user_event = self.get_object()
+            user_event = UserEvent.objects.get(event__pk=event_id, user__user_id=user_id)
             self.check_object_permissions(self.request, user_event)
             serializer = UserEventSerializer(user_event, data=request.data, partial=True, many=False)
 
@@ -234,7 +226,7 @@ class UserEventViewSet(viewsets.ModelViewSet):
             else:
                 return Response({'detail': _('Could not perform update')}, status=400)
 
-        except ObjectDoesNotExist:
+        except UserEvent.DoesNotExist:
             return Response({'detail': 'Could not find user event'}, status=400)
             
     def destroy(self, request, event_id, user_id):

--- a/app/content/views.py
+++ b/app/content/views.py
@@ -166,6 +166,9 @@ class UserEventViewSet(viewsets.ModelViewSet):
     queryset = UserEvent.objects.all()
     lookup_field = 'user_id' 
 
+    def get_object(self):
+        return UserEvent.objects.get(user__user_id=self.kwargs['user_id'], event__pk=self.kwargs['event_id'])
+
     def list(self, request, event_id):
         """ Returns all user events for given event """
         try:

--- a/app/content/views.py
+++ b/app/content/views.py
@@ -216,8 +216,27 @@ class UserEventViewSet(viewsets.ModelViewSet):
         else:
             return Response({'detail': serializer.errors}, status=400)
 
+    def partial_update(self, request, *args, **kwargs):
+        """ https://www.django-rest-framework.org/api-guide/serializers/#partial-updates """
+        try:
+            user_event = self.get_object()
+            self.check_object_permissions(self.request, user_event)
+            serializer = UserEventSerializer(user_event, data=request.data, partial=True)
+
+            if serializer.is_valid():
+                self.perform_update(serializer)
+                return Response({'detail': _('User event successfully updated.')})
+            else:
+                return Response({'detail': _('Could not perform update')}, status=400)
+        except ObjectDoesNotExist:
+            return Response({'detail': 'Could not find event'}, status=400)
+
     def update(self, request, *args, **kwargs):
-        """ Updates fields passed in request """
+        """ 
+        Updates fields passed in request 
+        TODO: Update only fields passed in request, without the need of sending the endtire object
+        """
+
         try:
             self.check_object_permissions(self.request, self.get_object())
             serializer = UserEventSerializer(self.get_object(), context={'request': request}, many=False, data=request.data)


### PR DESCRIPTION
# Fix updating user event
## One can now send a PUT request to 'events/:event_id/users/:user_id/' and only need to specify either field 'has_attended' or 'is_on_wait' to update the user event.
Link to Trello task: https://trello.com/c/S6TkTBOd/126-som-bruker-%C3%B8nsker-jeg-%C3%A5-melde-meg-p%C3%A5-arrangementer 

Comments/issues:
Still need to validate that the request is not trying to update read only fields, in this case 'user_event_id', 'event' and 'user'. There is not possible to alter these fields in a request, butthe api should respiond with a proper message saying that it is not possible.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] PR name is descriptive
- [x] The PR includes the link to the relevant Trello task
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

- [x] `python manage.py runserver` was run locally witout errors


## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):
