### PR TITLE
Feat/close event queue

### DIFF
--- a/app/content/models.py
+++ b/app/content/models.py
@@ -98,6 +98,7 @@ class User(BaseModel, OptionalImage):
     def __str__(self):
         return f'User - {self.user_id}: {self.first_name} {self.last_name}'
 
+
 class Event(BaseModel, OptionalImage):
     title = models.CharField(max_length=200)
     start = models.DateTimeField()
@@ -120,9 +121,6 @@ class Event(BaseModel, OptionalImage):
     closed = models.BooleanField(default=False)
     registered_users_list = models.ManyToManyField(User, through='UserEvent', through_fields=('event', 'user'), blank=True, default=None) 
 
-    def add_registration_list(self):
-        self.signup = True
-
     @property
     def expired(self):
         return self.start <= datetime.now(tz=timezone.utc)-timedelta(days=1)
@@ -130,12 +128,9 @@ class Event(BaseModel, OptionalImage):
     def __str__(self):
         return f'{self.title} - starting {self.start} at {self.location}'
 
+
 class UserEvent(BaseModel):
-    """
-    UserEvent
-        A RegistrationList can have 0 or many UserEvents. 
-        UserId (your school id) and regListId have to be primary keys in the UserEvents.
-    """
+    """ Model for users registrating for an event """
     user_event_id = models.AutoField(primary_key=True)
     user = models.ForeignKey(User, on_delete=models.CASCADE) 
     event = models.ForeignKey(Event, on_delete=models.CASCADE) 
@@ -151,13 +146,6 @@ class UserEvent(BaseModel):
         """ Validate and save instance """
         super(UserEvent, self).clean(*args, **kwargs)
         return super(UserEvent, self).save(*args, **kwargs)
-
-    def set_has_attended(self):
-        # when should this be called?
-        # if self.event.expired() and not is_on_wait:
-        #     self.has_attended = False
-        # return self.save()
-        pass
 
     def __str__(self):
         return f'{self.user.email} - is to attend {self.event} and is { "on the waitinglist" if self.is_on_wait else "on the list"}'

--- a/app/content/serializers.py
+++ b/app/content/serializers.py
@@ -82,7 +82,7 @@ class UserEventSerializer(serializers.ModelSerializer):
 
 class EventSerializer(serializers.ModelSerializer):
     expired = serializers.BooleanField(read_only=True)
-    registered_users_list = serializers.SerializerMethodField() 
+    registered_users_list = serializers.SerializerMethodField()
 
     class Meta:
         model = Event
@@ -94,11 +94,14 @@ class EventSerializer(serializers.ModelSerializer):
         ]
 
     def get_registered_users_list(self, obj):
-        """ Check permission/ownership of event """
+        """ Check permission/ownership of event and return only some user fields"""
         if self.context['request'].user.is_authenticated:
             try:
-                return [str(item) for item in obj.registered_users_list.all()]
+                return [{
+                    'user_id': user.user_id, 
+                    'first_name': user.first_name, 
+                    'last_name': user.last_name
+                    } for user in obj.registered_users_list.all()]        
             except User.DoesNotExist:
                 return None
         return None
-


### PR DESCRIPTION
# Edit events without having to send all required fields in request
## Frontend should be able to close the queue and change max amount of registered users with a PUT request to 'events/:id/'
Link to Trello task: https://trello.com/c/Vm994I5V/128-promo-hs-m%C3%A5-kunne-administrere-arrangement-p%C3%A5meldingen


Comments/issues:



## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] PR name is descriptive
- [x] The PR includes the link to the relevant Trello task
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

- [x] `python manage.py runserver` was run locally witout errors


## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
